### PR TITLE
Add compiler plugin template

### DIFF
--- a/compiler-plugin-template/build.gradle.kts
+++ b/compiler-plugin-template/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {}
+
+allprojects {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/compiler-plugin-template/gradle-plugin/build.gradle.kts
+++ b/compiler-plugin-template/gradle-plugin/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("jvm") version "2.0.0"
+    `java-gradle-plugin`
+}
+
+group = "org.mikrograd"
+version = "0.1-SNAPSHOT"
+
+dependencies {
+    implementation(kotlin("gradle-plugin-api"))
+    implementation(project(":plugin"))
+}
+
+gradlePlugin {
+    plugins {
+        create("simplePlugin") {
+            id = "org.mikrograd.simpleplugin"
+            implementationClass = "org.mikrograd.simpleplugin.SimpleGradlePlugin"
+        }
+    }
+}

--- a/compiler-plugin-template/gradle-plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleGradlePlugin.kt
+++ b/compiler-plugin-template/gradle-plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleGradlePlugin.kt
@@ -1,0 +1,25 @@
+package org.mikrograd.simpleplugin
+
+import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilation
+import org.jetbrains.kotlin.gradle.plugin.KotlinCompilerPluginSupportPlugin
+import org.jetbrains.kotlin.gradle.plugin.SubpluginArtifact
+import org.jetbrains.kotlin.gradle.plugin.SubpluginOption
+import javax.inject.Inject
+import org.gradle.api.provider.Provider
+
+class SimpleGradlePlugin @Inject constructor() : KotlinCompilerPluginSupportPlugin {
+    override fun apply(target: Project) {}
+
+    override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
+
+    override fun getCompilerPluginId(): String = "org.mikrograd.simpleplugin"
+
+    override fun getPluginArtifact(): SubpluginArtifact =
+        SubpluginArtifact("org.mikrograd", "plugin", "0.1-SNAPSHOT")
+
+    override fun getPluginArtifactForNative(): SubpluginArtifact? = null
+
+    override fun getOptions(project: Project, kotlinCompilation: KotlinCompilation<*>): Provider<Iterable<SubpluginOption>> =
+        project.provider { emptyList() }
+}

--- a/compiler-plugin-template/plugin/build.gradle.kts
+++ b/compiler-plugin-template/plugin/build.gradle.kts
@@ -1,0 +1,10 @@
+plugins {
+    kotlin("jvm") version "2.0.0"
+}
+
+group = "org.mikrograd"
+version = "0.1-SNAPSHOT"
+
+dependencies {
+    implementation(kotlin("compiler-embeddable"))
+}

--- a/compiler-plugin-template/plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleCommandLineProcessor.kt
+++ b/compiler-plugin-template/plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleCommandLineProcessor.kt
@@ -1,0 +1,12 @@
+package org.mikrograd.simpleplugin
+
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class SimpleCommandLineProcessor : CommandLineProcessor {
+    override val pluginId: String = "org.mikrograd.simpleplugin"
+    override val pluginOptions: Collection<CliOption> = emptyList()
+
+    override fun processOption(option: CliOption, value: String, configuration: CompilerConfiguration) {}
+}

--- a/compiler-plugin-template/plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleComponentRegistrar.kt
+++ b/compiler-plugin-template/plugin/src/main/kotlin/org/mikrograd/simpleplugin/SimpleComponentRegistrar.kt
@@ -1,0 +1,11 @@
+package org.mikrograd.simpleplugin
+
+import com.intellij.mock.MockProject
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class SimpleComponentRegistrar : ComponentRegistrar {
+    override fun registerProjectComponents(project: MockProject, configuration: CompilerConfiguration) {
+        println("Simple compiler plugin registered")
+    }
+}

--- a/compiler-plugin-template/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/compiler-plugin-template/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+org.mikrograd.simpleplugin.SimpleCommandLineProcessor

--- a/compiler-plugin-template/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+++ b/compiler-plugin-template/plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
@@ -1,0 +1,1 @@
+org.mikrograd.simpleplugin.SimpleComponentRegistrar

--- a/compiler-plugin-template/settings.gradle.kts
+++ b/compiler-plugin-template/settings.gradle.kts
@@ -1,0 +1,10 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "kotlin-plugin-template"
+include(":plugin")
+include(":gradle-plugin")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -2,6 +2,7 @@
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
+    id("org.mikrograd.simpleplugin")
 }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,8 @@ dependencyResolutionManagement {
     }
 }
 
+includeBuild("compiler-plugin-template")
+
 include(":core")
 include(":gguf")
 include(":dot-poet")


### PR DESCRIPTION
## Summary
- add an included build with a minimal Kotlin compiler plugin
- apply the plugin to the `core` module
- reference the included build from `settings.gradle.kts`

## Testing
- `./gradlew assmble` *(fails: Task 'assmble' not found)*
- `gradle assemble` *(fails: Plugin 'org.jetbrains.kotlin.jvm' not found due to no network access)*